### PR TITLE
buffer pointer API

### DIFF
--- a/hamr_buffer.h
+++ b/hamr_buffer.h
@@ -409,6 +409,20 @@ public:
     const T *data() const { return m_data.get(); }
     ///@}
 
+    /** @name pointer
+     * return the smart pointer managing the buffer contents. Use this when you
+     * know that the buffer contents are accessible by the code operating on
+     * them to save the costs of the logic that determines if a temporary is
+     * needed
+     */
+    ///@{
+    /// return a pointer to the buffer contents
+    std::shared_ptr<T> pointer() { return m_data; }
+
+    /// return a const pointer to the buffer contents
+    const std::shared_ptr<const T> pointer() const { return m_data; }
+    ///@}
+
     /// returns the allocator type enum
     allocator get_allocator() const { return m_alloc; }
 


### PR DESCRIPTION
the new API lets one access the std::shared_ptr managing the data
directly. this avoids to costs of the logic that determines when
a temporary copy is needed. it's only safe to use when one knows
where the data resides (much in the same way as the data API)