### PR TITLE
simplified data access patterns

### DIFF
--- a/doc/rtd/source/hello_cuda/Makefile
+++ b/doc/rtd/source/hello_cuda/Makefile
@@ -3,4 +3,4 @@ HAMR_SOURCE=../../../../
 HAMR_BUILD=../../../../build_cuda
 
 all:
-	nvcc hello_cuda.cu -I${HAMR_SOURCE} -I${HAMR_BUILD} -std=c++14 -L${HAMR_BUILD}/lib/ -lhamr
+	nvcc hello_cuda.cu -I${HAMR_SOURCE} -I${HAMR_BUILD} -std=c++17 -L${HAMR_BUILD}/lib/ -lhamr

--- a/doc/rtd/source/hello_cuda/add.h
+++ b/doc/rtd/source/hello_cuda/add.h
@@ -3,15 +3,13 @@
 template <typename T, typename U>
 hamr::buffer<T> add(const hamr::buffer<T> &a1, const hamr::buffer<U> &a2)
 {
-    // get pointers to the input arrays that are safe to use on the GPU
-    auto spa1 = a1.get_cuda_accessible();
-    const T *pa1 = spa1.get();
+    size_t n_vals = a1.size();
 
-    auto spa2 = a2.get_cuda_accessible();
-    const U *pa2 = spa2.get();
+    // get pointers to the input arrays that are safe to use on the GPU
+    auto [spa1, pa1] = hamr::get_cuda_accessible(a1);
+    auto [spa2, pa2] = hamr::get_cuda_accessible(a2);
 
     // allocate the memory for the result on the GPU, and get a pointer to it
-    size_t n_vals = a1.size();
     hamr::buffer<T> ao(hamr::buffer_allocator::cuda, n_vals, T(0));
     T *pao = ao.data();
 

--- a/doc/rtd/source/hello_cuda/hello_cuda.cu
+++ b/doc/rtd/source/hello_cuda/hello_cuda.cu
@@ -1,4 +1,5 @@
 #include <hamr_buffer.h>
+#include <hamr_buffer_util.h>
 #include <cuda.h>
 #include <cuda_runtime.h>
 #include <iostream>

--- a/doc/rtd/source/hello_hip/Makefile
+++ b/doc/rtd/source/hello_hip/Makefile
@@ -3,4 +3,4 @@ HAMR_SOURCE=../../../../
 HAMR_BUILD=../../../../build_hip
 
 all:
-	hipcc hello_hip.cpp -I${HAMR_SOURCE} -I${HAMR_BUILD} -std=c++14 -L${HAMR_BUILD}/lib/ -lhamr
+	hipcc hello_hip.cpp -I${HAMR_SOURCE} -I${HAMR_BUILD} -std=c++17 -L${HAMR_BUILD}/lib/ -lhamr

--- a/doc/rtd/source/hello_hip/add.h
+++ b/doc/rtd/source/hello_hip/add.h
@@ -3,15 +3,13 @@
 template <typename T, typename U>
 hamr::buffer<T> add(const hamr::buffer<T> &a1, const hamr::buffer<U> &a2)
 {
-    // get pointers to the input arrays that are safe to use on the GPU
-    auto spa1 = a1.get_hip_accessible();
-    const T *pa1 = spa1.get();
+    size_t n_vals = a1.size();
 
-    auto spa2 = a2.get_hip_accessible();
-    const U *pa2 = spa2.get();
+    // get pointers to the input arrays that are safe to use on the GPU
+    auto [spa1, pa1] = hamr::get_hip_accessible(a1);
+    auto [spa2, pa2] = hamr::get_hip_accessible(a2);
 
     // allocate the memory for the result on the GPU, and get a pointer to it
-    size_t n_vals = a1.size();
     hamr::buffer<T> ao(hamr::buffer_allocator::hip, n_vals, T(0));
     T *pao = ao.data();
 

--- a/doc/rtd/source/hello_hip/write.h
+++ b/doc/rtd/source/hello_hip/write.h
@@ -2,8 +2,7 @@ template <typename T>
 void write(std::ostream &os, const hamr::buffer<T> &ai)
 {
     // get pointer to the input array that is safe to use on the CPU
-    auto spai = ai.get_cpu_accessible();
-    const T *pai = spai.get();
+    auto [spai, pai] = hamr::get_cpu_accessible(ai);
 
     // write the elements of the array to the stream
     for (int i = 0; i < ai.size(); ++i)

--- a/doc/rtd/source/hello_openmp/Makefile
+++ b/doc/rtd/source/hello_openmp/Makefile
@@ -11,4 +11,4 @@ CXX=/opt/rocm/llvm/bin/amdclang++
 CXX_FLAGS=-target x86_64-pc-linux-gnu -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx1030
 
 all:
-	${CXX} ${CXX_FLAGS} hello_openmp.cpp -I${HAMR_SOURCE} -I${HAMR_BUILD} -std=c++14 -L${HAMR_BUILD}/lib/ -lhamr
+	${CXX} ${CXX_FLAGS} hello_openmp.cpp -I${HAMR_SOURCE} -I${HAMR_BUILD} -std=c++17 -L${HAMR_BUILD}/lib/ -lhamr

--- a/doc/rtd/source/hello_openmp/add.h
+++ b/doc/rtd/source/hello_openmp/add.h
@@ -1,15 +1,13 @@
 template <typename T, typename U>
 hamr::buffer<T> add(const hamr::buffer<T> &a1, const hamr::buffer<U> &a2)
 {
-    // get pointers to the input arrays that are safe to use on the GPU
-    auto spa1 = a1.get_openmp_accessible();
-    const T *pa1 = spa1.get();
+    size_t n_vals = a1.size();
 
-    auto spa2 = a2.get_openmp_accessible();
-    const U *pa2 = spa2.get();
+    // get pointers to the input arrays that are safe to use on the GPU
+    auto [spa1, pa1] = hamr::get_openmp_accessible(a1);
+    auto [spa2, pa2] = hamr::get_openmp_accessible(a2);
 
     // allocate the memory for the result on the GPU, and get a pointer to it
-    size_t n_vals = a1.size();
     hamr::buffer<T> ao(hamr::buffer_allocator::openmp, n_vals, T(0));
     T *pao = ao.data();
 

--- a/doc/rtd/source/hello_openmp/write.h
+++ b/doc/rtd/source/hello_openmp/write.h
@@ -2,8 +2,7 @@ template <typename T>
 void write(std::ostream &os, const hamr::buffer<T> &ai)
 {
     // get pointer to the input array that is safe to use on the CPU
-    auto spai = ai.get_cpu_accessible();
-    const T *pai = spai.get();
+    auto [spai, pai] = hamr::get_cpu_accessible(ai);
 
     // write the elements of the array to the stream
     for (size_t i = 0; i < ai.size(); ++i)

--- a/hamr_buffer.h
+++ b/hamr_buffer.h
@@ -2719,9 +2719,9 @@ std::shared_ptr<const T> buffer<T>::get_hip_accessible() const
             if (copy_to_hip_from_hip(tmp.get(), m_data.get(), m_owner, m_size))
                 return nullptr;
 
-        // synchronize
-        if (m_sync == transfer::sync)
-            m_stream.synchronize();
+            // synchronize
+            if (m_sync == transfer::sync)
+                m_stream.synchronize();
 
             return tmp;
         }

--- a/hamr_buffer.h
+++ b/hamr_buffer.h
@@ -659,63 +659,42 @@ public:
     ///@}
 
 #if !defined(SWIG)
-    /** @name get_cpu_accessible
-     * @returns a pointer to the contents of the buffer accessible on the CPU.
-     * If the buffer is currently accessible by codes running on the CPU then
-     * this call is a NOOP.  If the buffer is not currently accessible by codes
-     * running on the CPU then a temporary buffer is allocated and the data is
-     * moved to the CPU.  The returned shared_ptr deals with deallocation of
-     * the temporary if needed.
+    /** @returns a read only pointer to the contents of the buffer accessible on
+     * the CPU.  If the buffer is currently accessible by codes running on the
+     * CPU then this call is a NOOP.  If the buffer is not currently accessible
+     * by codes running on the CPU then a temporary buffer is allocated and the
+     * data is moved to the CPU.  The returned shared_ptr deals with
+     * deallocation of the temporary if needed.
      */
-    ///@{
-    /// returns a pointer to the contents of the buffer accessible on the CPU.
-    std::shared_ptr<T> get_cpu_accessible();
-
-    /// returns a pointer to the contents of the buffer accessible on the CPU.
     std::shared_ptr<const T> get_cpu_accessible() const;
-    ///@}
 #endif
 
     /// returns true if the data is accessible from codes running on the CPU
     int cpu_accessible() const;
 
 #if !defined(SWIG)
-    /** @name get_cuda_accessible
-     * @returns a pointer to the contents of the buffer accessible from the
-     * active CUDA device.  If the buffer is currently accessible on the active
-     * CUDA device then this call is a NOOP.  If the buffer is not currently
-     * accessible on the active CUDA device then a temporary buffer is allocated
-     * and the data is moved.  The returned shared_ptr deals with deallocation
-     * of the temporary if needed.
+    /** @returns a read only pointer to the contents of the buffer accessible
+     * from the active CUDA device.  If the buffer is currently accessible on
+     * the active CUDA device then this call is a NOOP.  If the buffer is not
+     * currently accessible on the active CUDA device then a temporary buffer
+     * is allocated and the data is moved.  The returned shared_ptr deals with
+     * deallocation of the temporary if needed.
      */
-    ///@{
-    /// returns a pointer to the contents of the buffer accessible from within CUDA
-    std::shared_ptr<T> get_cuda_accessible();
-
-    /// returns a pointer to the contents of the buffer accessible from within CUDA
     std::shared_ptr<const T> get_cuda_accessible() const;
-    ///@}
 #endif
 
     /// returns true if the data is accessible from CUDA codes
     int cuda_accessible() const;
 
 #if !defined(SWIG)
-    /** @name get_hip_accessible
-     * @returns a pointer to the contents of the buffer accessible from the
-     * active HIP device.  If the buffer is currently accessible on the active
-     * HIP device then this call is a NOOP.  If the buffer is not currently
-     * accessible on the active HIP device then a temporary buffer is allocated
-     * and the data is moved.  The returned shared_ptr deals with deallocation
-     * of the temporary if needed.
+    /** @returns a read only pointer to the contents of the buffer accessible
+     * from the active HIP device.  If the buffer is currently accessible on
+     * the active HIP device then this call is a NOOP.  If the buffer is not
+     * currently accessible on the active HIP device then a temporary buffer is
+     * allocated and the data is moved.  The returned shared_ptr deals with
+     * deallocation of the temporary if needed.
      */
-    ///@{
-    ///  returns a pointer to the contents of the buffer accessible from within HIP
-    std::shared_ptr<T> get_hip_accessible();
-
-    ///  returns a pointer to the contents of the buffer accessible from within HIP
     std::shared_ptr<const T> get_hip_accessible() const;
-    ///@}
 #endif
 
     /// returns true if the data is accessible from HIP codes
@@ -723,20 +702,15 @@ public:
 
 #if !defined(SWIG)
     /** @name get_openmp_accessible
-     * @returns a pointer to the contents of
-     * the buffer accessible from the active OpenMP off load device.  If the
-     * buffer is currently accessible on the active OpenMP off load device then
-     * this call is a NOOP.  If the buffer is not currently accessible on the
-     * active OpenMP off load device then a temporary buffer is allocated and
-     * the data is moved.  The returned shared_ptr deals with deallocation of
-     * the temporary if needed.
+     * @returns a read only pointer to the contents of the buffer accessible
+     * from the active OpenMP off load device.  If the buffer is currently
+     * accessible on the active OpenMP off load device then this call is a
+     * NOOP.  If the buffer is not currently accessible on the active OpenMP
+     * off load device then a temporary buffer is allocated and the data is
+     * moved.  The returned shared_ptr deals with deallocation of the temporary
+     * if needed.
      */
     ///@{
-    /** returns a pointer to the contents of the buffer accessible from within
-     * OpenMP off load
-     */
-    std::shared_ptr<T> get_openmp_accessible();
-
     /** returns a pointer to the contents of the buffer accessible from within
      * OpenMP off load
      */
@@ -748,22 +722,15 @@ public:
     int openmp_accessible() const;
 
 #if !defined(SWIG)
-    /** @name get_device_accessible
-     * @returns a pointer to the contents of the buffer accessible from the
-     * active device using the technology most suitable witht he current build
-     * configuration. If the buffer is currently accessible on the active
-     * device then this call is a NOOP.  If the buffer is not currently
-     * accessible on the active device then a temporary buffer is allocated and
-     * the data is moved.  The returned shared_ptr deals with deallocation of
-     * the temporary if needed.
+    /** @returns a read only pointer to the contents of the buffer accessible
+     * from the active device using the technology most suitable witht he
+     * current build configuration. If the buffer is currently accessible on
+     * the active device then this call is a NOOP.  If the buffer is not
+     * currently accessible on the active device then a temporary buffer is
+     * allocated and the data is moved.  The returned shared_ptr deals with
+     * deallocation of the temporary if needed.
      */
-    ///@{
-    ///  returns a pointer to the contents of the buffer accessible from within CUDA
-    std::shared_ptr<T> get_device_accessible();
-
-    ///  returns a pointer to the contents of the buffer accessible from within CUDA
     std::shared_ptr<const T> get_device_accessible() const;
-    ///@}
 #endif
 
     /** returns true if the data is accessible from device codes using the
@@ -772,9 +739,10 @@ public:
     int device_accessible() const;
 
     /** @name data
-     * return the raw pointer to the buffer contents. Use this when you know
-     * that the buffer contents are accessible by the code operating on them to
-     * save the cost of a std::shared_ptr copy construct.
+     * @returns a writable pointer to the buffer contents. Use this to modify
+     * the buffer contents or when you know that the buffer contents are
+     * accessible by the code operating on them to save the cost of a
+     * std::shared_ptr copy construct.
      */
     ///@{
     /// return a pointer to the buffer contents
@@ -785,16 +753,16 @@ public:
     ///@}
 
     /** @name pointer
-     * return the smart pointer managing the buffer contents. Use this when you
+     * @returns the smart pointer managing the buffer contents. Use this when you
      * know that the buffer contents are accessible by the code operating on
      * them to save the costs of the logic that determines if a temporary is
      * needed
      */
     ///@{
-    /// return a pointer to the buffer contents
+    /// @returns a pointer to the buffer contents
     std::shared_ptr<T> pointer() { return m_data; }
 
-    /// return a const pointer to the buffer contents
+    /// @returns a const pointer to the buffer contents
     const std::shared_ptr<const T> pointer() const { return m_data; }
     ///@}
 
@@ -2557,16 +2525,9 @@ int buffer<T>::get(size_t src_start,
     return 0;
 }
 
-// --------------------------------------------------------------------------
-template <typename T>
-std::shared_ptr<const T> buffer<T>::get_cpu_accessible() const
-{
-    return const_cast<buffer<T>*>(this)->get_cpu_accessible();
-}
-
 // ---------------------------------------------------------------------------
 template <typename T>
-std::shared_ptr<T> buffer<T>::get_cpu_accessible()
+std::shared_ptr<const T> buffer<T>::get_cpu_accessible() const
 {
     if ((m_alloc == allocator::cpp) || (m_alloc == allocator::malloc) ||
         (m_alloc == allocator::cuda_uva) || (m_alloc == allocator::cuda_host) ||
@@ -2650,13 +2611,6 @@ std::shared_ptr<T> buffer<T>::get_cpu_accessible()
 template <typename T>
 std::shared_ptr<const T> buffer<T>::get_cuda_accessible() const
 {
-    return const_cast<buffer<T>*>(this)->get_cuda_accessible();
-}
-
-// ---------------------------------------------------------------------------
-template <typename T>
-std::shared_ptr<T> buffer<T>::get_cuda_accessible()
-{
 #if !defined(HAMR_ENABLE_CUDA)
     std::cerr << "[" << __FILE__ << ":" << __LINE__ << "] ERROR:"
         " get_cuda_accessible failed, CUDA is not available."
@@ -2725,13 +2679,6 @@ std::shared_ptr<T> buffer<T>::get_cuda_accessible()
 template <typename T>
 std::shared_ptr<const T> buffer<T>::get_hip_accessible() const
 {
-    return const_cast<buffer<T>*>(this)->get_hip_accessible();
-}
-
-// ---------------------------------------------------------------------------
-template <typename T>
-std::shared_ptr<T> buffer<T>::get_hip_accessible()
-{
 #if !defined(HAMR_ENABLE_HIP)
     std::cerr << "[" << __FILE__ << ":" << __LINE__ << "] ERROR:"
         " get_hip_accessible failed, HIP is not available."
@@ -2795,13 +2742,6 @@ std::shared_ptr<T> buffer<T>::get_hip_accessible()
 template <typename T>
 std::shared_ptr<const T> buffer<T>::get_openmp_accessible() const
 {
-    return const_cast<buffer<T>*>(this)->get_openmp_accessible();
-}
-
-// ---------------------------------------------------------------------------
-template <typename T>
-std::shared_ptr<T> buffer<T>::get_openmp_accessible()
-{
 #if !defined(HAMR_ENABLE_OPENMP)
     std::cerr << "[" << __FILE__ << ":" << __LINE__ << "] ERROR:"
         " get_openmp_accessible failed, OpenMP is not available."
@@ -2864,13 +2804,6 @@ std::shared_ptr<T> buffer<T>::get_openmp_accessible()
 // ---------------------------------------------------------------------------
 template <typename T>
 std::shared_ptr<const T> buffer<T>::get_device_accessible() const
-{
-    return const_cast<buffer<T>*>(this)->get_device_accessible();
-}
-
-// ---------------------------------------------------------------------------
-template <typename T>
-std::shared_ptr<T> buffer<T>::get_device_accessible()
 {
 #if defined(HAMR_ENABLE_CUDA)
     return get_cuda_accessible();

--- a/hamr_buffer.i
+++ b/hamr_buffer.i
@@ -70,8 +70,11 @@
     {
         hamr::gil_state gil;
 
-        hamr::buffer_handle<T> h(self->get_cpu_accessible(), self->size(),
-            0, 1, self->cpu_accessible() && self->cuda_accessible(),
+        std::shared_ptr<T> ptr
+            (std::const_pointer_cast<T>(self->get_cpu_accessible()));
+
+        hamr::buffer_handle<T> h(ptr, self->size(), 0, 1,
+            self->cpu_accessible() && self->cuda_accessible(),
             self->get_stream().get_stream());
 
         return h;
@@ -82,8 +85,11 @@
     {
         hamr::gil_state gil;
 
-        hamr::buffer_handle<T> h(self->get_cuda_accessible(), self->size(),
-            0, self->cpu_accessible() && self->cuda_accessible(), 1,
+        std::shared_ptr<T> ptr
+            (std::const_pointer_cast<T>(self->get_cuda_accessible()));
+
+        hamr::buffer_handle<T> h(ptr, self->size(), 0,
+            self->cpu_accessible() && self->cuda_accessible(), 1,
             self->get_stream().get_stream());
 
         return h;

--- a/hamr_buffer.i
+++ b/hamr_buffer.i
@@ -1,6 +1,7 @@
 %{
 #include "hamr_config.h"
 #include "hamr_buffer.h"
+#include "hamr_buffer_util.h"
 #include "hamr_buffer_handle.h"
 #include "hamr_gil_state.h"
 #include "hamr_stream.h"
@@ -48,8 +49,7 @@
         size_t n_elem = self->size();
         if (n_elem)
         {
-            auto spb = self->get_cpu_accessible();
-            T *pb = spb.get();
+            auto [spb, pb] = get_cpu_accessible(*self);
 
             oss << pb[0];
 

--- a/hamr_buffer_allocator.h
+++ b/hamr_buffer_allocator.h
@@ -104,16 +104,17 @@ void assert_valid_allocator(buffer_allocator alloc)
 /// get the allocator type most suitable for the current build configuration
 inline HAMR_EXPORT buffer_allocator get_device_allocator()
 {
+    buffer_allocator alloc = buffer_allocator::malloc;
 #if defined(HAMR_ENABLE_CUDA)
-    return buffer_allocator::cuda;
+    alloc = buffer_allocator::cuda;
 #endif
 #if defined(HAMR_ENABLE_HIP)
-    return buffer_allocator::hip;
+    alloc = buffer_allocator::hip;
 #endif
 #if defined(HAMR_ENABLE_OPENMP)
-    return buffer_allocator::openmp;
+    alloc = buffer_allocator::openmp;
 #endif
-    return buffer_allocator::malloc;
+    return alloc;
 }
 
 }

--- a/hamr_buffer_util.h
+++ b/hamr_buffer_util.h
@@ -1,0 +1,184 @@
+#ifndef buffer_util_h
+#define buffer_util_h
+
+/// @file
+
+/// heterogeneous accelerator memory resource
+namespace hamr
+{
+
+/// @cond
+template <typename TT>
+auto get_cpu_accessible()
+{
+    return std::make_tuple();
+}
+/// @endcond
+
+/** Calls hamr::buffer::get_cpu_accessible on a number of hamr::buffer
+ * instances.
+ *
+ * @tparam TT hamr::buffer<NT>
+ * @tparam PP a paramater pack of TT
+ * @param b a hamr::buffer<NT> instance
+ * @param args zero or more hamr::buffer<NT> instances
+ * @returns a tuple of std::shared_ptr<NT> and NT* one for each
+ *          hamr::buffer<NT> passed in.
+ */
+template <typename TT, typename... PP>
+auto get_cpu_accessible(const TT &b, PP &&... args)
+{
+    auto spb = b.get_cpu_accessible();
+    return std::tuple_cat(std::make_tuple
+        (spb, spb.get()), get_cpu_accessible<TT>(args...));
+}
+
+/// @cond
+template <typename TT>
+auto get_cuda_accessible()
+{
+    return std::make_tuple();
+}
+/// @endcond
+
+/** Calls hamr::buffer::get_cuda_accessible on a number of hamr::buffer
+ * instances.
+ *
+ * @tparam TT hamr::buffer<NT>
+ * @tparam PP a paramater pack of TT
+ * @param b a hamr::buffer<NT> instance
+ * @param args zero or more hamr::buffer<NT> instances
+ * @returns a tuple of std::shared_ptr<NT> and NT* one for each
+ *          hamr::buffer<NT> passed in.
+ */
+template <typename TT, typename... PP>
+auto get_cuda_accessible(const TT &b, PP &&... args)
+{
+    auto spb = b.get_cuda_accessible();
+    return std::tuple_cat(std::make_tuple
+        (spb, spb.get()), get_cuda_accessible<TT>(args...));
+}
+
+/// @cond
+template <typename TT>
+auto get_hip_accessible()
+{
+    return std::make_tuple();
+}
+/// @endcond
+
+/** Calls hamr::buffer::get_hip_accessible on a number of hamr::buffer
+ * instances.
+ *
+ * @tparam TT hamr::buffer<NT>
+ * @tparam PP a paramater pack of TT
+ * @param b a hamr::buffer<NT> instance
+ * @param args zero or more hamr::buffer<NT> instances
+ * @returns a tuple of std::shared_ptr<NT> and NT* one for each
+ *          hamr::buffer<NT> passed in.
+ */
+template <typename TT, typename... PP>
+auto get_hip_accessible(const TT &b, PP &&... args)
+{
+    auto spb = b.get_hip_accessible();
+    return std::tuple_cat(std::make_tuple
+        (spb, spb.get()), get_hip_accessible<TT>(args...));
+}
+
+/// @cond
+template <typename TT>
+auto get_openmp_accessible()
+{
+    return std::make_tuple();
+}
+/// @endcond
+
+/** Calls hamr::buffer::get_openmp_accessible on a number of hamr::buffer
+ * instances.
+ *
+ * @tparam TT hamr::buffer<NT>
+ * @tparam PP a paramater pack of TT
+ * @param b a hamr::buffer<NT> instance
+ * @param args zero or more hamr::buffer<NT> instances
+ * @returns a tuple of std::shared_ptr<NT> and NT* one for each
+ *          hamr::buffer<NT> passed in.
+ */
+template <typename TT, typename... PP>
+auto get_openmp_accessible(const TT &b, PP &&... args)
+{
+    auto spb = b.get_openmp_accessible();
+    return std::tuple_cat(std::make_tuple
+        (spb, spb.get()), get_openmp_accessible<TT>(args...));
+}
+
+/// @cond
+template <typename TT>
+auto get_device_accessible()
+{
+    return std::make_tuple();
+}
+/// @endcond
+
+/** Calls hamr::buffer::get_device_accessible on a number of hamr::buffer
+ * instances.
+ *
+ * @tparam TT hamr::buffer<NT>
+ * @tparam PP a paramater pack of TT
+ * @param b a hamr::buffer<NT> instance
+ * @param args zero or more hamr::buffer<NT> instances
+ * @returns a tuple of std::shared_ptr<NT> and NT* one for each
+ *          hamr::buffer<NT> passed in.
+ */
+template <typename TT, typename... PP>
+auto get_device_accessible(const TT &b, PP &&... args)
+{
+    auto spb = b.get_device_accessible();
+    return std::tuple_cat(std::make_tuple
+        (spb, spb.get()), get_device_accessible<TT>(args...));
+}
+
+
+/** Calls hamr::buffer::data on a number of hamr::buffer<NT> instances.
+ *
+ * @tparam PP a paramater pack of hamr::buffer<NT>
+ * @param args any number of hamr::buffer<NT> instances
+ * @returns a tuple of NT* one for each hamr::buffer<NT> passed in.
+ */
+template <typename... PP>
+auto data(PP &&... args)
+{
+    return std::make_tuple(args.data()...);
+}
+
+/** constructs an un-initialized hamr::buffer<NT> with space for n_elem
+ * allocated and returns it along with the writable pointer to it's contents.
+ *
+ * @param[in] alloc the allocator to allocate memory with
+ * @param[in] n_elem the initial size of the allocated memory
+ * @returns a std::tuple with the newly constructed buffer in the first slot
+ *          and a writable pointer to its internal memory in the second
+ */
+template <typename NT>
+auto make_buffer(buffer_allocator alloc, size_t n_elem)
+{
+    hamr::buffer<NT> buf(alloc, n_elem);
+    return std::make_tuple(buf, buf.data());
+}
+
+/** constructs an hamr:buffer<NT> with space for n_elem allocated and
+ * initialized and returns it along with the writable pointer to it's contents.
+ *
+ * @param[in] alloc the allocator to allocate memory with
+ * @param[in] n_elem the initial size of the allocated memory
+ * @param[in] ival the value used to initialize the allocated memory
+ * @returns a std::tuple with the newly constructed buffer in the first slot
+ *          and a writable pointer to its internal memory in the second
+ */
+template <typename NT>
+auto make_buffer(buffer_allocator alloc, size_t n_elem, const NT &ival)
+{
+    hamr::buffer<NT> buf(alloc, n_elem, ival);
+    return std::make_tuple(buf, buf.data());
+}
+}
+#endif

--- a/test/test_hamr_multi_gpu_cuda.cpp
+++ b/test/test_hamr_multi_gpu_cuda.cpp
@@ -1,4 +1,5 @@
 #include "hamr_buffer.h"
+#include "hamr_buffer_util.h"
 
 #include <cuda.h>
 #include <cuda_runtime.h>
@@ -8,9 +9,7 @@
 template <typename T>
 void print(const hamr::buffer<T> &buf)
 {
-    auto spbuf = buf.get_cpu_accessible();
-    const T *pbuf = spbuf.get();
-
+    auto [spbuf, pbuf] = hamr::get_cpu_accessible(buf);
     std::cerr << pbuf[0];
     for (size_t i = 1; i < buf.size(); ++i)
         std::cerr << ", "<< pbuf[i];
@@ -81,8 +80,7 @@ int main(int argc, char **argv)
     // check for 31415
     std::cerr << " ==== validate ==== " << std::endl;
 
-    auto spsrc = src->get_cpu_accessible();
-    T *psrc = spsrc.get();
+    auto [spsrc, psrc] = hamr::get_cpu_accessible(*src);
 
     for (size_t i = 0; i < n_elem; ++i)
     {

--- a/test/test_hamr_multi_gpu_hip.cpp
+++ b/test/test_hamr_multi_gpu_hip.cpp
@@ -1,4 +1,5 @@
 #include "hamr_buffer.h"
+#include "hamr_buffer_util.h"
 
 #include <hip/hip_runtime.h>
 
@@ -8,8 +9,7 @@
 template <typename T>
 void print(const hamr::buffer<T> &buf)
 {
-    auto spbuf = buf.get_cpu_accessible();
-    const T *pbuf = spbuf.get();
+    auto [spbuf, pbuf] = hamr::get_cpu_accessible(buf);
 
     std::cerr << pbuf[0];
     for (size_t i = 1; i < buf.size(); ++i)
@@ -81,8 +81,7 @@ int main(int argc, char **argv)
     // check for 31415
     std::cerr << " ==== validate ==== " << std::endl;
 
-    auto spsrc = src->get_cpu_accessible();
-    T *psrc = spsrc.get();
+    auto [spsrc, psrc] = hamr::get_cpu_accessible(*src);
 
     for (size_t i = 0; i < n_elem; ++i)
     {

--- a/test/test_hamr_pipeline_cuda.cpp
+++ b/test/test_hamr_pipeline_cuda.cpp
@@ -1,4 +1,5 @@
 #include "hamr_buffer.h"
+#include "hamr_buffer_util.h"
 #include "hamr_cuda_launch.h"
 #include "hamr_buffer_pointer.h"
 
@@ -7,9 +8,7 @@
 
 #include <iostream>
 
-using std::make_shared;
 using hamr::buffer;
-using hamr::p_buffer;
 using allocator = hamr::buffer_allocator;
 
 
@@ -28,14 +27,11 @@ void initialize_cuda(T *data, double val, size_t n_vals)
 
 // **************************************************************************
 template <typename T>
-p_buffer<T> initialize_cuda(size_t n_vals, const T &val)
+buffer<T> initialize_cuda(size_t n_vals, const T &val)
 {
-    // allocate the memory
-    p_buffer<T> ao = make_shared<buffer<T>>(allocator::cuda);
-    ao->resize(n_vals);
-
-    auto spao = ao->get_cuda_accessible();
-    T *pao = spao.get();
+    // allocate the output
+    buffer<T> ao(allocator::cuda, n_vals);
+    T *pao = ao.data();
 
     // determine kernel launch parameters
     int n_blocks = 0;
@@ -45,7 +41,7 @@ p_buffer<T> initialize_cuda(size_t n_vals, const T &val)
         8, block_grid, n_blocks, thread_grid))
     {
         std::cerr << "ERROR: Failed to determine launch parameters" << std::endl;
-        return nullptr;
+        abort();
     }
 
     // initialize the data
@@ -55,18 +51,16 @@ p_buffer<T> initialize_cuda(size_t n_vals, const T &val)
     {
         std::cerr << "ERROR: Failed to launch the initialize_cuda kernel. "
             << cudaGetErrorString(ierr) << std::endl;
-        return nullptr;
+        abort();
     }
 
     std::cerr << "initialized to an array of " << n_vals << " to " << val << std::endl;
     if (n_vals < 33)
     {
-        std::cerr << "ao = "; ao->print(); std::cerr << std::endl;
-        ao->print();
+        std::cerr << "ao = "; ao.print(); std::cerr << std::endl;
+        ao.print();
         std::cerr << std::endl;
     }
-
-    //cudaDeviceSynchronize();
 
     return ao;
 }
@@ -91,23 +85,17 @@ void add_cuda(T *result, const T *array_1, const U *array_2, size_t n_vals)
 
 // **************************************************************************
 template <typename T, typename U>
-p_buffer<T> add_cuda(const p_buffer<T> &a1,
-    const p_buffer<U> &a2)
+buffer<T> add_cuda(const buffer<T> &a1, const buffer<U> &a2)
 {
+    size_t n_vals = a1.size();
+
     // get the inputs
-    auto spa1 = a1->get_cuda_accessible();
-    const T *pa1 = spa1.get();
+    auto [spa1, pa1] = hamr::get_cuda_accessible(a1);
+    auto [spa2, pa2] = hamr::get_cuda_accessible(a2);
 
-    auto spa2 = a2->get_cuda_accessible();
-    const U *pa2 = spa2.get();
-
-    // allocate the memory
-    size_t n_vals = a1->size();
-    p_buffer<T> ao = make_shared<buffer<T>>(allocator::cuda);
-    ao->resize(n_vals, T(0));
-
-    auto spao = ao->get_cuda_accessible();
-    T *pao = spao.get();
+    // allocate the output
+    buffer<T> ao(allocator::cuda, n_vals, T(0));
+    T *pao = ao.data();
 
     // determine kernel launch parameters
     int n_blocks = 0;
@@ -117,7 +105,7 @@ p_buffer<T> add_cuda(const p_buffer<T> &a1,
         8, block_grid, n_blocks, thread_grid))
     {
         std::cerr << "ERROR: Failed to determine launch parameters" << std::endl;
-        return nullptr;
+        abort();
     }
 
     // initialize the data
@@ -127,19 +115,17 @@ p_buffer<T> add_cuda(const p_buffer<T> &a1,
     {
         std::cerr << "ERROR: Failed to launch the add_cuda kernel. "
             << cudaGetErrorString(ierr) << std::endl;
-        return nullptr;
+        abort();
     }
 
     std::cerr << "added " << n_vals << " array " << typeid(T).name() << sizeof(T)
          << " to array  " << typeid(U).name() << sizeof(U) << std::endl;
     if (n_vals < 33)
     {
-        std::cerr << "a1 = "; a1->print(); std::cerr << std::endl;
-        std::cerr << "a2 = "; a2->print(); std::cerr << std::endl;
-        std::cerr << "ao = "; ao->print(); std::cerr << std::endl;
+        std::cerr << "a1 = "; a1.print(); std::cerr << std::endl;
+        std::cerr << "a2 = "; a2.print(); std::cerr << std::endl;
+        std::cerr << "ao = "; ao.print(); std::cerr << std::endl;
     }
-
-    //cudaDeviceSynchronize();
 
     return ao;
 }
@@ -163,19 +149,16 @@ void multiply_scalar_cuda(T *result, const T *array_in, U scalar, size_t n_vals)
 
 // **************************************************************************
 template <typename T, typename U>
-p_buffer<T> multiply_scalar_cuda(const p_buffer<T> &ain, const U &val)
+buffer<T> multiply_scalar_cuda(const buffer<T> &ai, const U &val)
 {
+    size_t n_vals = ai.size();
+
     // get the inputs
-    auto spain = ain->get_cuda_accessible();
-    const T *pain = spain.get();
+    auto [spai, pai] = hamr::get_cuda_accessible(ai);
 
-    // allocate the memory
-    size_t n_vals = ain->size();
-    p_buffer<T> ao = make_shared<buffer<T>>(allocator::cuda);
-    ao->resize(n_vals, T(0));
-
-    auto spao = ao->get_cuda_accessible();
-    T *pao = spao.get();
+    // allocate the output
+    buffer<T> ao(allocator::cuda, n_vals, T(0));
+    T *pao = ao.data();
 
     // determine kernel launch parameters
     int n_blocks = 0;
@@ -185,17 +168,17 @@ p_buffer<T> multiply_scalar_cuda(const p_buffer<T> &ain, const U &val)
         8, block_grid, n_blocks, thread_grid))
     {
         std::cerr << "ERROR: Failed to determine launch parameters" << std::endl;
-        return nullptr;
+        abort();
     }
 
     // initialize the data
     cudaError_t ierr = cudaSuccess;
-    multiply_scalar_cuda<<<block_grid, thread_grid>>>(pao, pain, val, n_vals);
+    multiply_scalar_cuda<<<block_grid, thread_grid>>>(pao, pai, val, n_vals);
     if ((ierr = cudaGetLastError()) != cudaSuccess)
     {
         std::cerr << "ERROR: Failed to launch the multiply_scalar_cuda kernel. "
             << cudaGetErrorString(ierr) << std::endl;
-        return nullptr;
+        abort();
     }
 
     std::cerr << "multiply_scalar " << val << " " << typeid(U).name() << sizeof(U)
@@ -203,11 +186,9 @@ p_buffer<T> multiply_scalar_cuda(const p_buffer<T> &ain, const U &val)
 
     if (n_vals < 33)
     {
-        std::cerr << "ain = "; ain->print(); std::cerr << std::endl;
-        std::cerr << "ao = "; ao->print(); std::cerr << std::endl;
+        std::cerr << "ai = "; ai.print(); std::cerr << std::endl;
+        std::cerr << "ao = "; ao.print(); std::cerr << std::endl;
     }
-
-    //cudaDeviceSynchronize();
 
     return ao;
 }
@@ -216,22 +197,20 @@ p_buffer<T> multiply_scalar_cuda(const p_buffer<T> &ain, const U &val)
 
 // **************************************************************************
 template <typename T>
-int compare_int(const p_buffer<T> &ain, int val)
+int compare_int(const buffer<T> &ain, int val)
 {
-    size_t n_vals = ain->size();
+    size_t n_vals = ain.size();
     std::cerr << "comparing array with " << n_vals << " elements to " << val << std::endl;
 
-    p_buffer<int> ai = make_shared<buffer<int>>(ain->get_allocator());
-    ai->resize(n_vals);
-    ain->get(ref_to(ai));
+    buffer<int> ai(ain.get_allocator(), n_vals);
+    ain.get(ai);
+
+    auto [spai, pai] = hamr::get_cpu_accessible(ai);
 
     if (n_vals < 33)
     {
-        ai->print();
+        ai.print();
     }
-
-    auto spai = ai->get_cpu_accessible();
-    int *pai = spai.get();
 
     for (size_t i = 0; i < n_vals; ++i)
     {
@@ -254,40 +233,29 @@ int main(int, char **)
 {
     size_t n_vals = 100000;
 
-    p_buffer<float>  ao0 = make_shared<buffer<float>>(allocator::cuda, n_vals, 1.0f);   // = 1 (CUDA)
-    p_buffer<float>  ao1 = multiply_scalar_cuda(ao0, 2.0f);                             // = 2 (CUDA)
-    ao0 = nullptr;
+    buffer<float>  ao0(allocator::cuda, n_vals, 1.0f);                                // = 1 (CUDA)
+    buffer<float>  ao1 = multiply_scalar_cuda(ao0, 2.0f);                             // = 2 (CUDA)
+    ao0.free();
 
-    p_buffer<double> ao2 = initialize_cuda(n_vals, 2.0);                                // = 2 (CUDA)
-    p_buffer<double> ao3 = add_cuda(ao2, ao1);                                          // = 4 (CUDA)
-    ao1 = nullptr;
-    ao2 = nullptr;
+    buffer<double> ao2 = initialize_cuda(n_vals, 2.0);                                // = 2 (CUDA)
+    buffer<double> ao3 = add_cuda(ao2, ao1);                                          // = 4 (CUDA)
+    ao1.free();
+    ao2.free();
 
-    p_buffer<double> ao4 = multiply_scalar_cuda(ao3, 1000.0);                           // = 4000 (CUDA)
-    ao3 = nullptr;
+    buffer<double> ao4 = multiply_scalar_cuda(ao3, 1000.0);                           // = 4000 (CUDA)
+    ao3.free();
 
-    p_buffer<float>  ao5 = make_shared<buffer<float>>(allocator::malloc, n_vals, 3.0f); // = 1 (CPU)
-    p_buffer<float>  ao6 = multiply_scalar_cuda(ao5, 100.0f);                           // = 300 (CUDA)
-    ao5 = nullptr;
+    buffer<float>  ao5(allocator::malloc, n_vals, 3.0f);                              // = 1 (CPU)
+    buffer<float>  ao6 = multiply_scalar_cuda(ao5, 100.0f);                           // = 300 (CUDA)
+    ao5.free();
 
-    p_buffer<float> ao7 = make_shared<buffer<float>>(allocator::malloc, n_vals);        // = uninit (CPU)
-    ao7->set(ref_to(ao6));                                                              // = 300 (CPU)
-    ao6 = nullptr;
+    buffer<float> ao7(allocator::malloc, n_vals);                                     // = uninit (CPU)
+    ao7.set(ao6);                                                                     // = 300 (CPU)
+    ao6.free();
 
-    p_buffer<double> ao8 = add_cuda(ao4, ao7);                                          // = 4300 (CUDA)
-    ao4 = nullptr;
-    ao7 = nullptr;
+    buffer<double> ao8 = add_cuda(ao4, ao7);                                          // = 4300 (CUDA)
+    ao4.free();
+    ao7.free();
 
     return compare_int(ao8, 4300);
-
-    /*
-    p_buffer<double> ao9 = make_shared<buffer<double>>(allocator::malloc);                // = empty (CPU)
-    ao9->assign(ao8);                                                                        // = 4300 (CPU)
-    ao8 = nullptr;
-
-    ao9->print();
-    ao9 = nullptr;
-
-    return 0;
-    */
 }

--- a/test/test_hamr_pipeline_hip.cpp
+++ b/test/test_hamr_pipeline_hip.cpp
@@ -1,4 +1,5 @@
 #include "hamr_buffer.h"
+#include "hamr_buffer_util.h"
 #include "hamr_hip_launch.h"
 #include "hamr_buffer_pointer.h"
 
@@ -7,11 +8,8 @@
 
 #include <iostream>
 
-using std::make_shared;
 using hamr::buffer;
-using hamr::p_buffer;
 using allocator = hamr::buffer_allocator;
-
 
 // **************************************************************************
 template<typename T>
@@ -28,14 +26,11 @@ void initialize_hip(T *data, double val, size_t n_vals)
 
 // **************************************************************************
 template <typename T>
-p_buffer<T> initialize_hip(size_t n_vals, const T &val)
+buffer<T> initialize_hip(size_t n_vals, const T &val)
 {
-    // allocate the memory
-    p_buffer<T> ao = make_shared<buffer<T>>(allocator::hip);
-    ao->resize(n_vals);
-
-    auto spao = ao->get_hip_accessible();
-    T *pao = spao.get();
+    // allocate the output
+    buffer<T> ao(allocator::hip, n_vals);
+    T *pao = ao.data();
 
     // determine kernel launch parameters
     int n_blocks = 0;
@@ -45,7 +40,7 @@ p_buffer<T> initialize_hip(size_t n_vals, const T &val)
         8, block_grid, n_blocks, thread_grid))
     {
         std::cerr << "ERROR: Failed to determine launch parameters" << std::endl;
-        return nullptr;
+        abort();
     }
 
     // initialize the data
@@ -55,14 +50,14 @@ p_buffer<T> initialize_hip(size_t n_vals, const T &val)
     {
         std::cerr << "ERROR: Failed to launch the initialize_hip kernel. "
             << hipGetErrorString(ierr) << std::endl;
-        return nullptr;
+        abort();
     }
 
     std::cerr << "initialized to an array of " << n_vals << " to " << val << std::endl;
     if (n_vals < 33)
     {
-        std::cerr << "ao = "; ao->print(); std::cerr << std::endl;
-        ao->print();
+        std::cerr << "ao = "; ao.print(); std::cerr << std::endl;
+        ao.print();
         std::cerr << std::endl;
     }
 
@@ -91,23 +86,17 @@ void add_hip(T *result, const T *array_1, const U *array_2, size_t n_vals)
 
 // **************************************************************************
 template <typename T, typename U>
-p_buffer<T> add_hip(const p_buffer<T> &a1,
-    const p_buffer<U> &a2)
+buffer<T> add_hip(const buffer<T> &a1, const buffer<U> &a2)
 {
+    size_t n_vals = a1.size();
+
     // get the inputs
-    auto spa1 = a1->get_hip_accessible();
-    const T *pa1 = spa1.get();
+    auto [spa1, pa1] = hamr::get_hip_accessible(a1);
+    auto [spa2, pa2] = hamr::get_hip_accessible(a2);
 
-    auto spa2 = a2->get_hip_accessible();
-    const U *pa2 = spa2.get();
-
-    // allocate the memory
-    size_t n_vals = a1->size();
-    p_buffer<T> ao = make_shared<buffer<T>>(allocator::hip);
-    ao->resize(n_vals, T(0));
-
-    auto spao = ao->get_hip_accessible();
-    T *pao = spao.get();
+    // allocate the output
+    buffer<T> ao(allocator::hip, n_vals, T(0));
+    T *pao = ao.data();
 
     // determine kernel launch parameters
     int n_blocks = 0;
@@ -117,7 +106,7 @@ p_buffer<T> add_hip(const p_buffer<T> &a1,
         8, block_grid, n_blocks, thread_grid))
     {
         std::cerr << "ERROR: Failed to determine launch parameters" << std::endl;
-        return nullptr;
+        abort();
     }
 
     // initialize the data
@@ -127,16 +116,16 @@ p_buffer<T> add_hip(const p_buffer<T> &a1,
     {
         std::cerr << "ERROR: Failed to launch the add_hip kernel. "
             << hipGetErrorString(ierr) << std::endl;
-        return nullptr;
+        abort();
     }
 
     std::cerr << "added " << n_vals << " array " << typeid(T).name() << sizeof(T)
          << " to array  " << typeid(U).name() << sizeof(U) << std::endl;
     if (n_vals < 33)
     {
-        std::cerr << "a1 = "; a1->print(); std::cerr << std::endl;
-        std::cerr << "a2 = "; a2->print(); std::cerr << std::endl;
-        std::cerr << "ao = "; ao->print(); std::cerr << std::endl;
+        std::cerr << "a1 = "; a1.print(); std::cerr << std::endl;
+        std::cerr << "a2 = "; a2.print(); std::cerr << std::endl;
+        std::cerr << "ao = "; ao.print(); std::cerr << std::endl;
     }
 
     //hipDeviceSynchronize();
@@ -163,19 +152,16 @@ void multiply_scalar_hip(T *result, const T *array_in, U scalar, size_t n_vals)
 
 // **************************************************************************
 template <typename T, typename U>
-p_buffer<T> multiply_scalar_hip(const p_buffer<T> &ain, const U &val)
+buffer<T> multiply_scalar_hip(const buffer<T> &ai, const U &val)
 {
+    size_t n_vals = ai.size();
+
     // get the inputs
-    auto spain = ain->get_hip_accessible();
-    const T *pain = spain.get();
+    auto [spai, pai] = hamr::get_hip_accessible(ai);
 
-    // allocate the memory
-    size_t n_vals = ain->size();
-    p_buffer<T> ao = make_shared<buffer<T>>(allocator::hip);
-    ao->resize(n_vals, T(0));
-
-    auto spao = ao->get_hip_accessible();
-    T *pao = spao.get();
+    // allocate the output
+    buffer<T> ao(allocator::hip, n_vals, T(0));
+    T *pao = ao.data();
 
     // determine kernel launch parameters
     int n_blocks = 0;
@@ -185,17 +171,17 @@ p_buffer<T> multiply_scalar_hip(const p_buffer<T> &ain, const U &val)
         8, block_grid, n_blocks, thread_grid))
     {
         std::cerr << "ERROR: Failed to determine launch parameters" << std::endl;
-        return nullptr;
+        abort();
     }
 
     // initialize the data
     hipError_t ierr = hipSuccess;
-    hipLaunchKernelGGL(HIP_KERNEL_NAME(multiply_scalar_hip), dim3(block_grid), dim3(thread_grid), 0, 0, pao, pain, val, n_vals);
+    hipLaunchKernelGGL(HIP_KERNEL_NAME(multiply_scalar_hip), dim3(block_grid), dim3(thread_grid), 0, 0, pao, pai, val, n_vals);
     if ((ierr = hipGetLastError()) != hipSuccess)
     {
         std::cerr << "ERROR: Failed to launch the multiply_scalar_hip kernel. "
             << hipGetErrorString(ierr) << std::endl;
-        return nullptr;
+        abort();
     }
 
     std::cerr << "multiply_scalar " << val << " " << typeid(U).name() << sizeof(U)
@@ -203,8 +189,8 @@ p_buffer<T> multiply_scalar_hip(const p_buffer<T> &ain, const U &val)
 
     if (n_vals < 33)
     {
-        std::cerr << "ain = "; ain->print(); std::cerr << std::endl;
-        std::cerr << "ao = "; ao->print(); std::cerr << std::endl;
+        std::cerr << "ain = "; ai.print(); std::cerr << std::endl;
+        std::cerr << "ao = "; ao.print(); std::cerr << std::endl;
     }
 
     //hipDeviceSynchronize();
@@ -216,22 +202,20 @@ p_buffer<T> multiply_scalar_hip(const p_buffer<T> &ain, const U &val)
 
 // **************************************************************************
 template <typename T>
-int compare_int(const p_buffer<T> &ain, int val)
+int compare_int(const buffer<T> &ain, int val)
 {
-    size_t n_vals = ain->size();
+    size_t n_vals = ain.size();
     std::cerr << "comparing array with " << n_vals << " elements to " << val << std::endl;
 
-    p_buffer<int> ai = make_shared<buffer<int>>(ain->get_allocator());
-    ai->resize(n_vals);
-    ain->get(ref_to(ai));
+    buffer<int> ai(ain.get_allocator(), n_vals);
+    ain.get(ai);
 
     if (n_vals < 33)
     {
-        ai->print();
+        ai.print();
     }
 
-    auto spai = ai->get_cpu_accessible();
-    int *pai = spai.get();
+    auto [spai, pai] = hamr::get_cpu_accessible(ai);
 
     for (size_t i = 0; i < n_vals; ++i)
     {
@@ -254,29 +238,29 @@ int main(int, char **)
 {
     size_t n_vals = 100000;
 
-    p_buffer<float>  ao0 = make_shared<buffer<float>>(allocator::hip, n_vals, 1.0f);    // = 1 (HIP)
-    p_buffer<float>  ao1 = multiply_scalar_hip(ao0, 2.0f);                              // = 2 (HIP)
-    ao0 = nullptr;
+    buffer<float>  ao0(allocator::hip, n_vals, 1.0f);    // = 1 (HIP)
+    buffer<float>  ao1 = multiply_scalar_hip(ao0, 2.0f);                              // = 2 (HIP)
+    ao0.free();
 
-    p_buffer<double> ao2 = initialize_hip(n_vals, 2.0);                                 // = 2 (HIP)
-    p_buffer<double> ao3 = add_hip(ao2, ao1);                                           // = 4 (HIP)
-    ao1 = nullptr;
-    ao2 = nullptr;
+    buffer<double> ao2 = initialize_hip(n_vals, 2.0);                                 // = 2 (HIP)
+    buffer<double> ao3 = add_hip(ao2, ao1);                                           // = 4 (HIP)
+    ao1.free();
+    ao2.free();
 
-    p_buffer<double> ao4 = multiply_scalar_hip(ao3, 1000.0);                            // = 4000 (HIP)
-    ao3 = nullptr;
+    buffer<double> ao4 = multiply_scalar_hip(ao3, 1000.0);                            // = 4000 (HIP)
+    ao3.free();
 
-    p_buffer<float>  ao5 = make_shared<buffer<float>>(allocator::malloc, n_vals, 3.0f); // = 1 (CPU)
-    p_buffer<float>  ao6 = multiply_scalar_hip(ao5, 100.0f);                            // = 300 (HIP)
-    ao5 = nullptr;
+    buffer<float>  ao5(allocator::malloc, n_vals, 3.0f); // = 1 (CPU)
+    buffer<float>  ao6 = multiply_scalar_hip(ao5, 100.0f);                            // = 300 (HIP)
+    ao5.free();
 
-    p_buffer<float> ao7 = make_shared<buffer<float>>(allocator::malloc, n_vals);        // = uninit (CPU)
-    ao7->set(ref_to(ao6));                                                              // = 300 (CPU)
-    ao6 = nullptr;
+    buffer<float> ao7(allocator::malloc, n_vals);        // = uninit (CPU)
+    ao7.set(ao6);                                                              // = 300 (CPU)
+    ao6.free();
 
-    p_buffer<double> ao8 = add_hip(ao4, ao7);                                           // = 4300 (HIP)
-    ao4 = nullptr;
-    ao7 = nullptr;
+    buffer<double> ao8 = add_hip(ao4, ao7);                                           // = 4300 (HIP)
+    ao4.free();
+    ao7.free();
 
     return compare_int(ao8, 4300);
 }


### PR DESCRIPTION
adds utilities to simplify data access patterns
makes buffer accessibility method const since it's not safe to modify buffer contents this way
updates the documentation